### PR TITLE
Ticket 102

### DIFF
--- a/src/main/java/ee/taltech/inbankbackend/config/DecisionEngineConstants.java
+++ b/src/main/java/ee/taltech/inbankbackend/config/DecisionEngineConstants.java
@@ -11,4 +11,7 @@ public class DecisionEngineConstants {
     public static final Integer SEGMENT_1_CREDIT_MODIFIER = 100;
     public static final Integer SEGMENT_2_CREDIT_MODIFIER = 300;
     public static final Integer SEGMENT_3_CREDIT_MODIFIER = 1000;
+    public static final Integer MAXIMUM_LIFETIME_FEMALE = 83;
+    public static final Integer MAXIMUM_LIFETIME_MALE = 75;
+    public static final Integer MINIMUM_LOAN_AGE = 18;
 }

--- a/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionEngineController.java
+++ b/src/main/java/ee/taltech/inbankbackend/endpoint/DecisionEngineController.java
@@ -58,7 +58,8 @@ public class DecisionEngineController {
             response.setErrorMessage(decision.getErrorMessage());
 
             return ResponseEntity.ok(response);
-        } catch (InvalidPersonalCodeException | InvalidLoanAmountException | InvalidLoanPeriodException e) {
+        } catch (InvalidPersonalCodeException | InvalidLoanAmountException | InvalidLoanPeriodException
+                | InvalidPersonalAgeException e) {
             return handleException(HttpStatus.BAD_REQUEST, e.getMessage());
         } catch (NoValidLoanException e) {
             return handleException(HttpStatus.NOT_FOUND, e.getMessage());

--- a/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidPersonalAgeException.java
+++ b/src/main/java/ee/taltech/inbankbackend/exceptions/InvalidPersonalAgeException.java
@@ -1,0 +1,28 @@
+package ee.taltech.inbankbackend.exceptions;
+
+/**
+ * Thrown when user is too young or too old to apply for a loan.
+ */
+public class InvalidPersonalAgeException extends Throwable {
+    private final String message;
+    private final Throwable cause;
+
+    public InvalidPersonalAgeException(String message) {
+        this(message, null);
+    }
+
+    public InvalidPersonalAgeException(String message, Throwable cause) {
+        this.message = message;
+        this.cause = cause;
+    }
+
+    @Override
+    public Throwable getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/ee/taltech/inbankbackend/service/DecisionEngine.java
+++ b/src/main/java/ee/taltech/inbankbackend/service/DecisionEngine.java
@@ -36,10 +36,12 @@ public class DecisionEngine {
      * @throws NoValidLoanException         If there is no valid loan found for the
      *                                      given ID code, loan amount and loan
      *                                      period
+     * @throws InvalidPersonalAgeException  If the customer is too young or too old
+     *                                      or too risky to apply for a loan
      */
     public Decision calculateApprovedLoan(String personalCode, Long loanAmount, int loanPeriod)
             throws InvalidPersonalCodeException, InvalidLoanAmountException, InvalidLoanPeriodException,
-            NoValidLoanException {
+            NoValidLoanException, InvalidPersonalAgeException {
         Validator.validatePersonalCode(personalCode);
         Validator.validateLoanAmount(loanAmount);
         Validator.validateLoanPeriod(loanPeriod);
@@ -62,6 +64,8 @@ public class DecisionEngine {
         } else {
             throw new NoValidLoanException("You are not eligible for a loan!");
         }
+
+        Validator.validateAgeForLoanPeriod(personalCode, loanPeriod);
 
         return new Decision(outputLoanAmount, loanPeriod, null);
     }

--- a/src/test/java/ee/taltech/inbankbackend/endpoint/DecisionEngineControllerTest.java
+++ b/src/test/java/ee/taltech/inbankbackend/endpoint/DecisionEngineControllerTest.java
@@ -33,188 +33,210 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 public class DecisionEngineControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @MockBean
-    private DecisionEngine decisionEngine;
+        @MockBean
+        private DecisionEngine decisionEngine;
 
-    private ObjectMapper objectMapper;
+        private ObjectMapper objectMapper;
 
-    @BeforeEach
-    public void setup() {
-        objectMapper = new ObjectMapper();
-    }
+        @BeforeEach
+        public void setup() {
+                objectMapper = new ObjectMapper();
+        }
 
-    /**
-     * This method tests the /loan/decision endpoint with valid inputs.
-     */
-    @Test
-    public void givenValidRequest_whenRequestDecision_thenReturnsExpectedResponse()
-            throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
-        Decision decision = new Decision(1000, 12, null);
-        when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt())).thenReturn(decision);
+        /**
+         * This method tests the /loan/decision endpoint with valid inputs.
+         */
+        @Test
+        public void givenValidRequest_whenRequestDecision_thenReturnsExpectedResponse()
+                        throws Exception, InvalidLoanPeriodException, NoValidLoanException,
+                        InvalidPersonalCodeException,
+                        InvalidLoanAmountException, InvalidPersonalAgeException {
+                Decision decision = new Decision(1000, 12, null);
+                when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt())).thenReturn(decision);
 
-        DecisionRequest request = new DecisionRequest("1234", 10L, 10);
+                DecisionRequest request = new DecisionRequest("1234", 10L, 10);
 
-        MvcResult result = mockMvc.perform(post("/loan/decision")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.loanAmount").value(1000))
-                .andExpect(jsonPath("$.loanPeriod").value(12))
-                .andExpect(jsonPath("$.errorMessage").isEmpty())
-                .andReturn();
+                MvcResult result = mockMvc.perform(post("/loan/decision")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.loanAmount").value(1000))
+                                .andExpect(jsonPath("$.loanPeriod").value(12))
+                                .andExpect(jsonPath("$.errorMessage").isEmpty())
+                                .andReturn();
 
-        DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), DecisionResponse.class);
-        assert response.getLoanAmount() == 1000;
-        assert response.getLoanPeriod() == 12;
-        assert response.getErrorMessage() == null;
-    }
+                DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                DecisionResponse.class);
+                assert response.getLoanAmount() == 1000;
+                assert response.getLoanPeriod() == 12;
+                assert response.getErrorMessage() == null;
+        }
 
-    /**
-     * This test ensures that if an invalid personal code is provided, the controller returns
-     * an HTTP Bad Request (400) response with the appropriate error message in the response body.
-     */
-    @Test
-    public void givenInvalidPersonalCode_whenRequestDecision_thenReturnsBadRequest()
-            throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
-        when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
-                .thenThrow(new InvalidPersonalCodeException("Invalid personal code"));
+        /**
+         * This test ensures that if an invalid personal code is provided, the
+         * controller returns
+         * an HTTP Bad Request (400) response with the appropriate error message in the
+         * response body.
+         */
+        @Test
+        public void givenInvalidPersonalCode_whenRequestDecision_thenReturnsBadRequest()
+                        throws Exception, InvalidLoanPeriodException, NoValidLoanException,
+                        InvalidPersonalCodeException,
+                        InvalidLoanAmountException, InvalidPersonalAgeException {
+                when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
+                                .thenThrow(new InvalidPersonalCodeException("Invalid personal code"));
 
-        DecisionRequest request = new DecisionRequest("1234", 10L, 10);
+                DecisionRequest request = new DecisionRequest("1234", 10L, 10);
 
-        MvcResult result = mockMvc.perform(post("/loan/decision")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.loanAmount").isEmpty())
-                .andExpect(jsonPath("$.loanPeriod").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value("Invalid personal code"))
-                .andReturn();
+                MvcResult result = mockMvc.perform(post("/loan/decision")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.loanAmount").isEmpty())
+                                .andExpect(jsonPath("$.loanPeriod").isEmpty())
+                                .andExpect(jsonPath("$.errorMessage").value("Invalid personal code"))
+                                .andReturn();
 
-        DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), DecisionResponse.class);
-        assert response.getLoanAmount() == null;
-        assert response.getLoanPeriod() == null;
-        assert response.getErrorMessage().equals("Invalid personal code");
-    }
+                DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                DecisionResponse.class);
+                assert response.getLoanAmount() == null;
+                assert response.getLoanPeriod() == null;
+                assert response.getErrorMessage().equals("Invalid personal code");
+        }
 
-    /**
-     * This test ensures that if an invalid loan amount is provided, the controller returns
-     * an HTTP Bad Request (400) response with the appropriate error message in the response body.
-     */
-    @Test
-    public void givenInvalidLoanAmount_whenRequestDecision_thenReturnsBadRequest()
-            throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
-        when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
-                .thenThrow(new InvalidLoanAmountException("Invalid loan amount"));
+        /**
+         * This test ensures that if an invalid loan amount is provided, the controller
+         * returns
+         * an HTTP Bad Request (400) response with the appropriate error message in the
+         * response body.
+         */
+        @Test
+        public void givenInvalidLoanAmount_whenRequestDecision_thenReturnsBadRequest()
+                        throws Exception, InvalidLoanPeriodException, NoValidLoanException,
+                        InvalidPersonalCodeException,
+                        InvalidLoanAmountException, InvalidPersonalAgeException {
+                when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
+                                .thenThrow(new InvalidLoanAmountException("Invalid loan amount"));
 
-        DecisionRequest request = new DecisionRequest("1234", 10L, 10);
+                DecisionRequest request = new DecisionRequest("1234", 10L, 10);
 
-        MvcResult result = mockMvc.perform(post("/loan/decision")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.loanAmount").isEmpty())
-                .andExpect(jsonPath("$.loanPeriod").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value("Invalid loan amount"))
-                .andReturn();
+                MvcResult result = mockMvc.perform(post("/loan/decision")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.loanAmount").isEmpty())
+                                .andExpect(jsonPath("$.loanPeriod").isEmpty())
+                                .andExpect(jsonPath("$.errorMessage").value("Invalid loan amount"))
+                                .andReturn();
 
-        DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), DecisionResponse.class);
-        assert response.getLoanAmount() == null;
-        assert response.getLoanPeriod() == null;
-        assert response.getErrorMessage().equals("Invalid loan amount");
-    }
+                DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                DecisionResponse.class);
+                assert response.getLoanAmount() == null;
+                assert response.getLoanPeriod() == null;
+                assert response.getErrorMessage().equals("Invalid loan amount");
+        }
 
-    /**
-     * This test ensures that if an invalid loan period is provided, the controller returns
-     * an HTTP Bad Request (400) response with the appropriate error message in the response body.
-     */
-    @Test
-    public void givenInvalidLoanPeriod_whenRequestDecision_thenReturnsBadRequest()
-            throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
-        when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
-                .thenThrow(new InvalidLoanPeriodException("Invalid loan period"));
+        /**
+         * This test ensures that if an invalid loan period is provided, the controller
+         * returns
+         * an HTTP Bad Request (400) response with the appropriate error message in the
+         * response body.
+         */
+        @Test
+        public void givenInvalidLoanPeriod_whenRequestDecision_thenReturnsBadRequest()
+                        throws Exception, InvalidLoanPeriodException, NoValidLoanException,
+                        InvalidPersonalCodeException,
+                        InvalidLoanAmountException, InvalidPersonalAgeException {
+                when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
+                                .thenThrow(new InvalidLoanPeriodException("Invalid loan period"));
 
-        DecisionRequest request = new DecisionRequest("1234", 10L, 10);
+                DecisionRequest request = new DecisionRequest("1234", 10L, 10);
 
-        MvcResult result = mockMvc.perform(post("/loan/decision")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.loanAmount").isEmpty())
-                .andExpect(jsonPath("$.loanPeriod").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value("Invalid loan period"))
-                .andReturn();
+                MvcResult result = mockMvc.perform(post("/loan/decision")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.loanAmount").isEmpty())
+                                .andExpect(jsonPath("$.loanPeriod").isEmpty())
+                                .andExpect(jsonPath("$.errorMessage").value("Invalid loan period"))
+                                .andReturn();
 
-        DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), DecisionResponse.class);
-        assert response.getLoanAmount() == null;
-        assert response.getLoanPeriod() == null;
-        assert response.getErrorMessage().equals("Invalid loan period");
-    }
+                DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                DecisionResponse.class);
+                assert response.getLoanAmount() == null;
+                assert response.getLoanPeriod() == null;
+                assert response.getErrorMessage().equals("Invalid loan period");
+        }
 
-    /**
-     * This test ensures that if no valid loan is found, the controller returns
-     * an HTTP Bad Request (400) response with the appropriate error message in the response body.
-     */
-    @Test
-    public void givenNoValidLoan_whenRequestDecision_thenReturnsBadRequest()
-            throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
-        when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
-                .thenThrow(new NoValidLoanException("No valid loan available"));
+        /**
+         * This test ensures that if no valid loan is found, the controller returns
+         * an HTTP Bad Request (400) response with the appropriate error message in the
+         * response body.
+         */
+        @Test
+        public void givenNoValidLoan_whenRequestDecision_thenReturnsBadRequest()
+                        throws Exception, InvalidLoanPeriodException, NoValidLoanException,
+                        InvalidPersonalCodeException,
+                        InvalidLoanAmountException, InvalidPersonalAgeException {
+                when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
+                                .thenThrow(new NoValidLoanException("No valid loan available"));
 
-        DecisionRequest request = new DecisionRequest("1234", 1000L, 12);
+                DecisionRequest request = new DecisionRequest("1234", 1000L, 12);
 
-        MvcResult result = mockMvc.perform(post("/loan/decision")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.loanAmount").isEmpty())
-                .andExpect(jsonPath("$.loanPeriod").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value("No valid loan available"))
-                .andReturn();
+                MvcResult result = mockMvc.perform(post("/loan/decision")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isNotFound())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.loanAmount").isEmpty())
+                                .andExpect(jsonPath("$.loanPeriod").isEmpty())
+                                .andExpect(jsonPath("$.errorMessage").value("No valid loan available"))
+                                .andReturn();
 
-        DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), DecisionResponse.class);
-        assert response.getLoanAmount() == null;
-        assert response.getLoanPeriod() == null;
-        assert response.getErrorMessage().equals("No valid loan available");
-    }
+                DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                DecisionResponse.class);
+                assert response.getLoanAmount() == null;
+                assert response.getLoanPeriod() == null;
+                assert response.getErrorMessage().equals("No valid loan available");
+        }
 
-    /**
-     * This test ensures that if an unexpected error occurs when processing the request, the controller returns
-     * an HTTP Internal Server Error (500) response with the appropriate error message in the response body.
-     */
-    @Test
-    public void givenUnexpectedError_whenRequestDecision_thenReturnsInternalServerError()
-            throws Exception, InvalidLoanPeriodException, NoValidLoanException, InvalidPersonalCodeException,
-            InvalidLoanAmountException {
-        when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt())).thenThrow(new RuntimeException());
+        /**
+         * This test ensures that if an unexpected error occurs when processing the
+         * request, the controller returns
+         * an HTTP Internal Server Error (500) response with the appropriate error
+         * message in the response body.
+         */
+        @Test
+        public void givenUnexpectedError_whenRequestDecision_thenReturnsInternalServerError()
+                        throws Exception, InvalidLoanPeriodException, NoValidLoanException,
+                        InvalidPersonalCodeException,
+                        InvalidLoanAmountException, InvalidPersonalAgeException {
+                when(decisionEngine.calculateApprovedLoan(anyString(), anyLong(), anyInt()))
+                                .thenThrow(new RuntimeException());
 
-        DecisionRequest request = new DecisionRequest("1234", 10L, 10);
+                DecisionRequest request = new DecisionRequest("1234", 10L, 10);
 
-        MvcResult result = mockMvc.perform(post("/loan/decision")
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isInternalServerError())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.loanAmount").isEmpty())
-                .andExpect(jsonPath("$.loanPeriod").isEmpty())
-                .andExpect(jsonPath("$.errorMessage").value("An unexpected error occurred"))
-                .andReturn();
+                MvcResult result = mockMvc.perform(post("/loan/decision")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isInternalServerError())
+                                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(jsonPath("$.loanAmount").isEmpty())
+                                .andExpect(jsonPath("$.loanPeriod").isEmpty())
+                                .andExpect(jsonPath("$.errorMessage").value("An unexpected error occurred"))
+                                .andReturn();
 
-        DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(), DecisionResponse.class);
-        assert response.getLoanAmount() == null;
-        assert response.getLoanPeriod() == null;
-        assert response.getErrorMessage().equals("An unexpected error occurred");
-    }
+                DecisionResponse response = objectMapper.readValue(result.getResponse().getContentAsString(),
+                                DecisionResponse.class);
+                assert response.getLoanAmount() == null;
+                assert response.getLoanPeriod() == null;
+                assert response.getErrorMessage().equals("An unexpected error occurred");
+        }
 }


### PR DESCRIPTION
This PR closes `TICKET-102` from backlog and resolves it.

### Implementation

We are using `EstonianPersonalCodeParser` to get users age from their personal code. After that, we supplement loan period and check for 3 conditions:
1. User is not underage.
2. If the user is male, check if his age with added loan period is under the currently expected lifetime of a man.
2. If the user is female, check if his age with added loan period is under the currently expected lifetime of a female.

If one of the condition fails, we throw `InvalidPersonalAgeException`

### Test coverage

I've added 3 test cases for underage, older than the current expected lifetime and if age is too risky (current age + loan period).